### PR TITLE
Add UserProxy to AppSection

### DIFF
--- a/app/Containers/AppSection/User/Models/UserProxy.php
+++ b/app/Containers/AppSection/User/Models/UserProxy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Containers\AppSection\User\Models;
+
+use App\Containers\MarketPalace\User\Models\UserProxy as ParentUserProxy;
+
+class UserProxy extends ParentUserProxy
+{
+}


### PR DESCRIPTION
In \App\Ship\Parents\Providers\MainServiceProvider class, method resetProxy tries to create UserProxy namespace using proxyForClass method of \App\Ship\Utils\Proxifier class, but the files aren't in the same directory.

I solve this problem by adding a UserProxy class that extends the main one and put it inside the app\Containers\AppSection\User\Models directory.